### PR TITLE
Allow custom config paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,16 @@
 
 This library can be used for managing server- and client-side configs.
 
-All configs are stored in `.json` files (see examples in `sample-config`). At boot-up time, the server decides which config file to use based on the `NODE_ENV` environment variable. The default value is `"development"`. For values shared across environments, add them to the `_shared.json` file. The entire configuration is available on the server-side and most keys are also exposed to the client.
+All configs are stored in `.json` files (see examples in `sample-config`). The path to where these files are stored needs to be specified via the `CALYPSO_CONFIG_PATH` environment variable.
+
+At boot-up time, the server decides which config file to use based on the `NODE_ENV` environment variable. The default value is `"development"`. For values shared across environments, add them to the `_shared.json` file. The entire configuration is available on the server-side and certain keys can be exposed to the client.
+
+## Server-side Usage
 
 Config values can be retrieved by invoking the `config()` exported function with the desired key name:
 
 ```js
-import config from 'config';
+import config from '@automattic/calypso-config';
 console.log( config( 'redirect_uri' ) );
 ```
 
@@ -18,7 +22,7 @@ To access `config` values on the client-side, add the property name to the `clie
 A global `configData` object must also be output during the initial render. Here's an example using React:
 
 ```js
-import config from 'calypso-config';
+import { clientData } from '@automattic/calypso-config';
 
 class Document extends React.Component {
 	render() {
@@ -28,7 +32,7 @@ class Document extends React.Component {
 			<script
 				type="text/javascript"
 				dangerouslySetInnerHTML={ {
-					__html: `var configData = ${ JSON.stringify( config.clientData ) };`
+					__html: `var configData = ${ JSON.stringify( clientData ) };`
 				} }
 			/>
 

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -1,0 +1,12 @@
+describe( 'config', () => {
+	it( 'should return config with valid path', () => {
+		process.env.CALYPSO_CONFIG_PATH = require( 'path' ).resolve( __dirname, '..', 'sample-config' );
+
+		const config = require( '../src/' );
+
+		expect( config( 'env_id' ) ).toEqual( 'test' );
+		expect( config ).toHaveProperty( 'serverData' );
+		expect( config ).toHaveProperty( 'clientData' );
+	} );
+
+});

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@automattic/calypso-config",
   "version": "1.0.0",
   "description": "Simple server and client config module. Originally written for wp-calypso.",
-  "main": "index.js",
+  "main": "src/index.js",
   "directories": {
     "test": "__tests__"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,26 @@
-const configPath = require( 'path' ).resolve( __dirname, '..', '..', 'config' );
 const createConfig = require( './create-config' );
 
-const { serverData, clientData } = require( './parser' )( configPath, {
-	env: process.env.CALYPSO_ENV || process.env.NODE_ENV || 'development',
-	enabledFeatures: process.env.ENABLE_FEATURES,
-	disabledFeatures: process.env.DISABLE_FEATURES
-} );
+let configApi = () => {};
+let serverData = {};
+let clientData = {};
 
-module.exports = createConfig( serverData );
+const configPath = process.env.CALYPSO_CONFIG_PATH || null;
+if ( configPath ) {
+	const data = require( './parser' )( configPath, {
+		env: process.env.CALYPSO_ENV || process.env.NODE_ENV || 'development',
+		enabledFeatures: process.env.ENABLE_FEATURES,
+		disabledFeatures: process.env.DISABLE_FEATURES
+	} );
+
+	serverData = data.serverData;
+	clientData = data.clientData;
+	configApi = createConfig( serverData );
+} else {
+	if ( 'development' === process.env.NODE_ENV ) {
+		throw new ReferenceError( '`CALYPSO_CONFIG_PATH` environment variable not defined. Please see calypso-config\'s `README.md` for more details.' );
+	}
+}
+
+module.exports = configApi;
+module.exports.serverData = serverData;
 module.exports.clientData = clientData;


### PR DESCRIPTION
To use this as dependency in other projects, they need to be able to specify where the config files are located. This can be done via an environment variable (`CALYPSO_CONFIG_PATH`).