### PR TITLE
Fall back to `config` in cwd()

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 This library can be used for managing server- and client-side configs.
 
-All configs are stored in `.json` files (see examples in `sample-config`). The path to where these files are stored needs to be specified via the `CALYPSO_CONFIG_PATH` environment variable.
+All configs are stored in `.json` files (see examples in `sample-config`) in a `config` folder in your working directory. This path can be overridden via the `CALYPSO_CONFIG_PATH` environment variable.
 
-At boot-up time, the server decides which config file to use based on the `NODE_ENV` environment variable. The default value is `"development"`. For values shared across environments, add them to the `_shared.json` file. The entire configuration is available on the server-side and certain keys can be exposed to the client.
+At boot-up time, the server decides which config file to use based on the `NODE_ENV` environment variable. The default value is `development`. For values shared across environments, add them to the `_shared.json` file. Local-only values can be added via a `{environment}.local.json` file (e.g. `development.local.json`).
+
+The entire configuration is available on the server-side and certain keys can be exposed to the client.
 
 ## Server-side Usage
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automattic/calypso-config",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Simple server and client config module. Originally written for wp-calypso.",
   "main": "src/index.js",
   "directories": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,12 @@
+const path = require( 'path' );
+
 const createConfig = require( './create-config' );
 
 let configApi = () => {};
 let serverData = {};
 let clientData = {};
 
-const configPath = process.env.CALYPSO_CONFIG_PATH || null;
+const configPath = process.env.CALYPSO_CONFIG_PATH || path.join( process.cwd(), 'config' );
 if ( configPath ) {
 	const data = require( './parser' )( configPath, {
 		env: process.env.CALYPSO_ENV || process.env.NODE_ENV || 'development',
@@ -17,7 +19,7 @@ if ( configPath ) {
 	configApi = createConfig( serverData );
 } else {
 	if ( 'development' === process.env.NODE_ENV ) {
-		throw new ReferenceError( '`CALYPSO_CONFIG_PATH` environment variable not defined. Please see calypso-config\'s `README.md` for more details.' );
+		throw new ReferenceError( '`CALYPSO_CONFIG_PATH` environment variable not defined or empty. Please see calypso-config\'s `README.md` for more details.' );
 	}
 }
 


### PR DESCRIPTION
If the PATH env var is not set. Allows for easier integration of the module.